### PR TITLE
build: use binary distribution for mccabe and pylint (they don't buil…

### DIFF
--- a/layers/layer7_python2_devtools/0500_extra_python_packages/allow_binary_packages
+++ b/layers/layer7_python2_devtools/0500_extra_python_packages/allow_binary_packages
@@ -1,0 +1,2 @@
+mccabe
+pylint


### PR DESCRIPTION
…d from source distribution anymore)