### PR TITLE
feat: bump urllib3 from 1.25.11 to 1.26.5 to fix security alert GHSA-…

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -65,7 +65,7 @@
 | [PyYAML](https://pyyaml.org/) | 5.4.1 | python2 |
 | [redis](https://github.com/andymccurdy/redis-py) | 3.2.1 | python2 |
 | [requests-unixsocket](https://github.com/msabramo/requests-unixsocket) | 0.2.0 | python2 |
-| [requests](http://python-requests.org) | 2.22.0 | python2 |
+| [requests](https://requests.readthedocs.io) | 2.25.1 | python2 |
 | [scandir](https://github.com/benhoyt/scandir) | 1.10.0 | python2_devtools |
 | [setuptools-scm](https://github.com/pypa/setuptools_scm/) | 3.5.0 | python2 |
 | [setuptools](https://pypi.python.org/pypi/setuptools) | 41.0.1 | python2_core |
@@ -79,7 +79,7 @@
 | [testfixtures](https://github.com/Simplistix/testfixtures) | 6.10.3 | python2_devtools |
 | [typing](https://docs.python.org/3/library/typing.html) | 3.7.4.1 | python2_devtools |
 | [Unidecode](https://pypi.org/project/Unidecode) | 1.1.1 | python2 |
-| [urllib3](https://urllib3.readthedocs.io/) | 1.25.11 | python2 |
+| [urllib3](https://urllib3.readthedocs.io/) | 1.26.5 | python2 |
 | [virtualenv](https://virtualenv.pypa.io/) | 16.6.0 | python2_core |
 | [wcwidth](https://github.com/jquast/wcwidth) | 0.1.8 | python2_devtools |
 | [Werkzeug](https://palletsprojects.com/p/werkzeug/) | 0.16.0 | python2_devtools |

--- a/layers/layer2_python2/0500_extra_python_packages/requirements2.txt
+++ b/layers/layer2_python2/0500_extra_python_packages/requirements2.txt
@@ -26,12 +26,12 @@ pathlib==1.0.1
 psutil==5.6.6
 PyYAML==5.4.1
 redis==3.2.1
-requests==2.22.0
+requests==2.25.1
 requests-unixsocket==0.2.0
 simpleeval==0.9.10
 -e git+https://github.com/thefab/pystatsd.git@075001fef55d1caefdd74a55c40db84d829e7edd#egg=statsd
 structlog==19.1.0
 terminaltables==3.1.0
 Unidecode==1.1.1
-urllib3==1.25.11
+urllib3==1.26.5
 -e git+https://github.com/metwork-framework/xattrfile.git@9c0b2974deeafed59caa3659c685a89e686a0159#egg=xattrfile


### PR DESCRIPTION
…q2q7-5pp4-w6pg (also bump requests from 2.22.0 to 2.25.1 for compatibity)